### PR TITLE
Remove redundant TypeScriptCompile exclusion for Home.razor.ts

### DIFF
--- a/Blazor.PowerPoint.AddIn.Client/Blazor.PowerPoint.AddIn.Client.csproj
+++ b/Blazor.PowerPoint.AddIn.Client/Blazor.PowerPoint.AddIn.Client.csproj
@@ -14,14 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TypeScriptCompile Remove="Pages\Home.razor.ts" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="Pages\Home.razor.ts" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.4" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.14.0" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Emoji" Version="4.14.0" />


### PR DESCRIPTION
Closes #10

## Summary

The TypeScript migration of `commands.js` is complete on `main`. `commands.ts` compiles correctly, all generated `.js`/`.js.map` files are gitignored, and the build succeeds with 0 errors/warnings.

## Change

Removes two spurious items from `Blazor.PowerPoint.AddIn.Client.csproj` that were added as a workaround when `Home.razor.ts` had compilation errors:

```xml
<!-- REMOVED -->
<TypeScriptCompile Remove="Pages\Home.razor.ts" />
<None Include="Pages\Home.razor.ts" />
```

**Why these were wrong:**
- With `Microsoft.TypeScript.MSBuild`, when `tsconfig.json` is present, `tsc` uses it to determine which files to compile. The `TypeScriptCompile Remove` did **not** prevent `tsc` from compiling `Home.razor.ts` (it's matched by `Pages/**/*.ts` in tsconfig's `include`).
- It **did** remove the file from MSBuild's incremental build input tracking, so changes to `Home.razor.ts` could be silently skipped on incremental builds.

The workaround is no longer needed — `Home.razor.ts` compiles cleanly, and removing these items restores correct MSBuild tracking.